### PR TITLE
IAM service support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typedoc": "^0.8.0",
     "typescript": "^2.1.6",
     "webpack": "^3.5.6",
-    "webpack-dev-server": "^2.8.1"
+    "webpack-dev-server": "^2.8.1",
+    "query-string": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/angular": "^1.6.7",
     "@types/angular-material": "^1.1.45",
     "@types/node": "^7.0.5",
-    "angular": "^1.6.2",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^6.2.10",

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,11 @@ import angular from 'angular';
 import {AppModule} from 'metabolica';
 import {LoginModule} from './login/login.module';
 export {LoginModule} from './login/login.module';
+import {SessionModule} from './session/session.module';
+export {SessionModule} from './session/session.module';
 
 export const LoginAppModule = angular.module('LoginApp', [
   AppModule.name,
   LoginModule.name,
+  SessionModule.name,
 ]);

--- a/src/login/login.component.html
+++ b/src/login/login.component.html
@@ -36,7 +36,7 @@
                    ng-change="loginForm.password.$setValidity('auth', true)"
                    id="email"
                    name="email"
-                   type="text"
+                   type="email"
                    required>
 
             <div ng-messages="loginForm.email.$error" ng-if="loginForm.email.$touched">

--- a/src/login/login.component.html
+++ b/src/login/login.component.html
@@ -29,18 +29,18 @@
 
           <md-input-container class="md-icon-float md-icon-left"> <!--TODO: md-icon-left is a temp fix, remove once AM fixes this-->
             <!-- Use floating label instead of placeholder -->
-            <label>Username</label>
+            <label>Email</label>
             <md-icon>person</md-icon>
             <input ng-disabled="loginForm.$submitted"
-                   ng-model="ctrl.credentials.username"
+                   ng-model="ctrl.credentials.email"
                    ng-change="loginForm.password.$setValidity('auth', true)"
-                   id="username"
-                   name="username"
+                   id="email"
+                   name="email"
                    type="text"
                    required>
 
-            <div ng-messages="loginForm.username.$error" ng-if="loginForm.username.$touched">
-              <div ng-message="required">You <b>must</b> specify a username.</div>
+            <div ng-messages="loginForm.email.$error" ng-if="loginForm.email.$touched">
+              <div ng-message="required">You <b>must</b> specify an email address.</div>
             </div>
           </md-input-container>
 
@@ -58,7 +58,7 @@
 
             <div ng-messages="loginForm.password.$error" ng-if="loginForm.password.$touched">
               <div ng-message="required">You <b>must</b> specify a password.</div>
-              <div ng-message="auth">Your username or password are incorrect.</div>
+              <div ng-message="auth">Your email address or password is incorrect.</div>
             </div>
           </md-input-container>
 

--- a/src/login/login.component.ts
+++ b/src/login/login.component.ts
@@ -12,7 +12,7 @@ firebase.initializeApp({
 });
 
 interface Credentials {
-  username: string;
+  email: string;
   password: string;
 }
 
@@ -31,7 +31,7 @@ class LoginSocialController {
   constructor($scope, $timeout, $window, Session, appName: string) {
     this.appName = appName;
     this.credentials = {
-      username: '',
+      email: '',
       password: ''
     };
 

--- a/src/login/login.component.ts
+++ b/src/login/login.component.ts
@@ -64,7 +64,7 @@ class LoginSocialController {
       }
       firebase.auth().signInWithPopup(providers[provider]).then((result) => {
         firebase.auth().currentUser.getToken(true).then((idToken) => {
-          this.authenticate(form, {'uid': result.user.uid, 'token': idToken}, true);
+          this.authenticate(form, {uid: result.user.uid, token: idToken}, true);
         }).catch(function(error) {
           console.log(error);
         });

--- a/src/login/login.component.ts
+++ b/src/login/login.component.ts
@@ -11,33 +11,28 @@ firebase.initializeApp({
   messagingSenderId: process.env.FIREBASE_SENDER_ID
 });
 
-interface Credentials {
-  email: string;
-  password: string;
-}
-
 /** This class is LoginComponent's controller */
 class LoginSocialController {
   appName: string;
-  credentials: Credentials;
-  authenticate: (form: any, credentials: Credentials, socialAuth: boolean) => void;
+  credentials: object;
+  authenticate: (form: any, credentials: object, firebase: boolean) => void;
   signInWithSocial: (form: any, provider: string) => void;
 
   /**
    * LoginController class constructor
-   * @param Session  comment login Session parameter
-   * @param appName  The application name to show during login
+   * @param Session  login Session parameter
+   * @param appName       The application name to show during login
    */
-  constructor($scope, $timeout, $window, Session, appName: string) {
+  constructor($scope, $timeout, $window, Session, appName: string, $state) {
     this.appName = appName;
     this.credentials = {
       email: '',
-      password: ''
+      password: '',
     };
 
-    this.authenticate = async (form: any, credentials: Credentials) => {
+    this.authenticate = async (form: any, credentials: object, firebase: boolean = false) => {
       try {
-        await Session.authenticate(credentials);
+        await Session.authenticate(credentials, firebase);
         // need to refresh the page before proceeding
         $timeout(() => {
           $window.location.href = '/app/home';
@@ -69,7 +64,7 @@ class LoginSocialController {
       }
       firebase.auth().signInWithPopup(providers[provider]).then((result) => {
         firebase.auth().currentUser.getToken(true).then((idToken) => {
-          this.authenticate(form, {'username': result.user.uid, 'password': idToken});
+          this.authenticate(form, {'uid': result.user.uid, 'token': idToken}, true);
         }).catch(function(error) {
           console.log(error);
         });

--- a/src/login/login.component.ts
+++ b/src/login/login.component.ts
@@ -14,7 +14,7 @@ firebase.initializeApp({
 /** This class is LoginComponent's controller */
 class LoginSocialController {
   appName: string;
-  credentials: object;
+  credentials: UserCredentials;
   authenticate: (form: any, credentials: object, firebase: boolean) => void;
   signInWithSocial: (form: any, provider: string) => void;
 
@@ -30,7 +30,7 @@ class LoginSocialController {
       password: '',
     };
 
-    this.authenticate = async (form: any, credentials: object, firebase: boolean = false) => {
+    this.authenticate = async (form: any, credentials: UserCredentials | FirebaseCredentials, firebase: boolean = false) => {
       try {
         await Session.authenticate(credentials, firebase);
         // need to refresh the page before proceeding

--- a/src/login/login.d.ts
+++ b/src/login/login.d.ts
@@ -7,3 +7,13 @@ declare module "*.json" {
   const json: string;
   export default json;
 }
+
+interface UserCredentials {
+  email: string,
+  password: string,
+}
+
+interface FirebaseCredentials {
+  uid: string,
+  token: string,
+}

--- a/src/session/session.d.ts
+++ b/src/session/session.d.ts
@@ -1,0 +1,13 @@
+interface SessionFactory {
+  isAuthenticated(): boolean
+  expired(): boolean
+  expires(): Date
+  authorizationExpired(): boolean
+  authorizationExpires(): Date
+  getCurrentUser(): null
+  refresh()
+  authenticate(credentials: UserCredentials | FirebaseCredentials, firebase)
+  invalidate(): void
+  logout(next: string): void
+  login(next: string): void
+}

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -155,7 +155,7 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
     },
     responseError(response) {
       if (response.status === 401 && appAuth.isRequired) {
-        $injector.get('Session').logout(location.pathname);
+        $injector.get('Session').invalidate();
       }
       return $q.reject(response);
     }

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -1,0 +1,124 @@
+import angular from 'angular';
+import 'ngstorage';
+import querystring from 'query-string';
+
+
+function SessionFactory($http, $localStorage, $rootScope, $log, $state) {
+  return {
+    isAuthenticated() {
+      return !this.refreshExpired();
+    },
+
+    jwtExpired() {
+      if (!$localStorage.jwt) {
+        return true;
+      }
+      return this.jwtExpires() <= new Date();
+    },
+
+    jwtExpires() {
+      if (!$localStorage.jwt) {
+        return;
+      }
+      return new Date(JSON.parse(atob($localStorage.jwt.split('.')[1])).exp * 1000);
+    },
+
+    refreshExpired() {
+      if (!$localStorage.refresh_token) {
+        return true;
+      }
+      return this.refreshExpires() <= new Date();
+    },
+
+    refreshExpires() {
+      if(!$localStorage.refresh_token) {
+        return;
+      }
+      return new Date(JSON.parse($localStorage.refresh_token.exp) * 1000);
+    },
+
+    getCurrentUser() {
+      // metabolica-core user system is not in use
+      return null;
+    },
+
+    authenticate(credentials, firebase) {
+      const params = querystring.stringify(credentials);
+      const endpoint = firebase ? '/authenticate/firebase' : '/authenticate/local';
+      return $http.post(`${process.env.IAM_API}${endpoint}`, params, {
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      }).then(response => {
+        $log.info("Authentication successful, saving received tokens in local storage");
+        $localStorage.jwt = response.data.jwt;
+        $localStorage.refresh_token = response.data.refresh_token;
+        $rootScope.$broadcast('session:login');
+        $rootScope.isAuthenticated = true;
+      }).catch(error => {
+        $log.info(`Authentication failure`);
+        $log.debug(error);
+        throw error;
+      });
+    },
+
+    logout(next = null) {
+      delete $localStorage.jwt;
+      delete $localStorage.refresh_token;
+      $rootScope.$broadcast('session:logout', {next});
+      $rootScope.isAuthenticated = false;
+    },
+
+    login(next = null) {
+      $state.go('login');
+    }
+  };
+}
+
+
+// TODO: refresh token logic
+function SessionInterceptorFactory($q, $injector, appAuth) {
+  return {
+    request(config) {
+      let $localStorage = $injector.get('$localStorage');
+
+      // Authorization header should be passed to trusted hosts only
+      if ($localStorage.jwt && appAuth.isTrustedURL(config.url)) {
+        config.headers.Authorization = `Bearer ${$localStorage.jwt}`;
+      }
+      return config;
+    },
+    responseError(response) {
+      if (response.status === 401) {
+        if (appAuth.isRequired) {
+          $injector.get('Session').logout(location.pathname);
+        }
+      }
+      return $q.reject(response);
+    }
+  };
+}
+
+export const SessionModule = angular
+  .module('decaf.session', [
+    'ngStorage'
+  ])
+  .factory('Session', SessionFactory)
+  .factory('sessionInterceptor', SessionInterceptorFactory)
+  .run(function ($rootScope, $state, $location, $log, $mdDialog, Session, Project, appAuth) {
+
+    if (!Session.isAuthenticated()) {
+      $rootScope.isAuthenticated = false;
+      if (appAuth.isRequired) {
+        setTimeout(() => {
+          let next;
+          if (!$state.includes('login')) {
+            next = $location.path();
+          }
+          $rootScope.$broadcast('session:logout', {next});
+        }, 100);
+      }
+    } else {
+      $rootScope.isAuthenticated = true;
+      $log.debug("NOTE: metabolica-ui Session module is overridden, but may still produce message 'Session expires undefined' above");
+      $log.info(`Session expires: ${Session.refreshExpires()}, JWT expires: ${Session.jwtExpires()}`);
+    }
+  });

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -101,9 +101,9 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
 
   return {
     request(config) {
-      let $localStorage = $injector.get('$localStorage');
-      let Session = $injector.get('Session');
-      let $log = $injector.get('$log');
+      const $localStorage = $injector.get('$localStorage');
+      const Session = $injector.get('Session');
+      const $log = $injector.get('$log');
 
       // Ignore authorization logic if there is no active session
       if (!$localStorage.authorization_token) {

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -176,7 +176,7 @@ export const SessionModule = angular
   ])
   .factory('Session', SessionFactory)
   .factory('sessionInterceptor', SessionInterceptorFactory)
-  .run(($rootScope, $state, $location, $log, $mdDialog, Session, Project, appAuth, $mdToast) => {
+  .run(($rootScope, $state, $location, $log, $mdDialog, Session, Project, appAuth) => {
 
     if (!Session.isAuthenticated()) {
       $rootScope.isAuthenticated = false;

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -154,6 +154,7 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
       return config;
     },
     responseError(response) {
+      // TODO this should only trigger for local API urls
       if (response.status === 401 && appAuth.isRequired) {
         $injector.get('Session').invalidate();
       }

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -10,10 +10,7 @@ function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast
     },
 
     expired() {
-      if (!$localStorage.refresh_token) {
-        return true;
-      }
-      return this.expires() <= new Date();
+      return !$localStorage.refresh_token || this.expires() <= new Date();
     },
 
     expires() {
@@ -21,10 +18,7 @@ function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast
     },
 
     authorizationExpired() {
-      if (!$localStorage.authorization_token) {
-        return true;
-      }
-      return this.authorizationExpires() <= new Date();
+      return !$localStorage.authorization_token || this.authorizationExpires() <= new Date();
     },
 
     authorizationExpires() {
@@ -160,10 +154,8 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
       return config;
     },
     responseError(response) {
-      if (response.status === 401) {
-        if (appAuth.isRequired) {
-          $injector.get('Session').logout(location.pathname);
-        }
+      if (response.status === 401 && appAuth.isRequired) {
+        $injector.get('Session').logout(location.pathname);
       }
       return $q.reject(response);
     }

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -37,12 +37,12 @@ function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast
     },
 
     refresh() {
-      $log.info("Session: Refreshing JWT");
+      $log.info("Session: Refreshing authorization token");
       return $http.post(`${process.env.IAM_API}/refresh`, `refresh_token=${$localStorage.refresh_token.val}`, {
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         refreshTokenRequest: true,
       }).then(response => {
-        $log.info("Session: Token refresh successful, saving new JWT in local storage");
+        $log.info("Session: Token refresh successful, saving new authorization token in local storage");
         $localStorage.authorization_token = response.data;
       }).catch(error => {
         $log.info(`Session: Token refresh failure`);
@@ -96,7 +96,7 @@ function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast
 
 function SessionInterceptorFactory($q, $injector, appAuth) {
 
-  // Points to any ongoing request for refreshing the JWT. Further requests should wait for this promise to resolve.
+  // Points to any ongoing request for refreshing the authorization token. Further requests should wait for this promise to resolve.
   let refreshTokenPromise;
 
   return {
@@ -110,7 +110,7 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
         return config;
       }
 
-      // Ignore authorization logic for requests to refresh the JWT
+      // Ignore authorization logic for requests to refresh the authorization token
       if (config.refreshTokenRequest) {
         return config;
       }
@@ -130,7 +130,7 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
 
       // If the authorization token has expired, refresh it
       if (Session.authorizationExpired()) {
-        $log.info(`SessionInterceptor: Request must wait for refreshed JWT`);
+        $log.info(`SessionInterceptor: Request must wait for refreshed authorization token`);
 
         // Check for a reference to existing refresh request. If none, then create one
         if (!refreshTokenPromise) {
@@ -159,7 +159,7 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
         });
       }
 
-      // Add the current JWT
+      // Add the current authorization token
       $log.debug(`SessionInterceptor: Adding authorization header for URL: ${config.url}`);
       config.headers.Authorization = `Bearer ${$localStorage.authorization_token}`;
       return config;

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -31,12 +31,12 @@ function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast
     },
 
     refresh() {
-      $log.info("Session: Refreshing authorization token");
+      $log.info('Session: Refreshing authorization token');
       return $http.post(`${process.env.IAM_API}/refresh`, `refresh_token=${$localStorage.refresh_token.val}`, {
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         refreshTokenRequest: true,
       }).then(response => {
-        $log.info("Session: Token refresh successful, saving new authorization token in local storage");
+        $log.info('Session: Token refresh successful, saving new authorization token in local storage');
         $localStorage.authorization_token = response.data;
       }).catch(error => {
         $log.info(`Session: Token refresh failure`);

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -176,7 +176,7 @@ export const SessionModule = angular
   ])
   .factory('Session', SessionFactory)
   .factory('sessionInterceptor', SessionInterceptorFactory)
-  .run(function ($rootScope, $state, $location, $log, $mdDialog, Session, Project, appAuth, $mdToast) {
+  .run(($rootScope, $state, $location, $log, $mdDialog, Session, Project, appAuth, $mdToast) => {
 
     if (!Session.isAuthenticated()) {
       $rootScope.isAuthenticated = false;

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -105,18 +105,13 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
       const Session = $injector.get('Session');
       const $log = $injector.get('$log');
 
-      // Ignore authorization logic if there is no active session
-      if (!$localStorage.authorization_token) {
-        return config;
-      }
-
-      // Ignore authorization logic for requests to refresh the authorization token
-      if (config.refreshTokenRequest) {
-        return config;
-      }
-
-      // Ignore authorization logic for untrusted hosts
-      if (!appAuth.isTrustedURL(config.url)) {
+      // Ignore authorization logic:
+      // - there is no active session
+      // - for requests to refresh the authorization token
+      // - for untrusted hosts
+      if (!$localStorage.authorization_token ||
+          config.refreshTokenRequest ||
+          !appAuth.isTrustedURL(config.url)) {
         return config;
       }
 

--- a/src/session/session.module.js
+++ b/src/session/session.module.js
@@ -146,8 +146,10 @@ function SessionInterceptorFactory($q, $injector, appAuth) {
           });
         }
 
-        // Wait for the refresh request promise, then return the current config as-is
+        // Wait for the refresh request promise, then add the new authorization token
         return refreshTokenPromise.then(() => {
+          $log.debug(`SessionInterceptor: Adding authorization header for URL: ${config.url}`);
+          config.headers.Authorization = `Bearer ${$localStorage.authorization_token}`;
           return config;
         }).catch(() => {
           $log.info(`SessionInterceptor: Auth token refresh failed, aborting request`);

--- a/src/session/session.module.ts
+++ b/src/session/session.module.ts
@@ -1,4 +1,4 @@
-import angular from 'angular';
+import * as angular from 'angular';
 import 'ngstorage';
 import querystring from 'query-string';
 

--- a/src/session/session.module.ts
+++ b/src/session/session.module.ts
@@ -49,8 +49,8 @@ function SessionFactory($http: ng.IHttpService, $localStorage, $rootScope, $log:
       return $http.post(`${process.env.IAM_API}${endpoint}`, params, {
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
       }).then(response => {
-        $localStorage.authorization_token = response.data.jwt;
-        $localStorage.refresh_token = response.data.refresh_token;
+        $localStorage.authorization_token = response.data['jwt'];
+        $localStorage.refresh_token = response.data['refresh_token'];
         $rootScope.$broadcast('session:login');
         $rootScope.isAuthenticated = true;
         $log.info(`Session: Authentication successful. Session expires: ${this.expires()}, authorization expires: ${this.authorizationExpires()}`);
@@ -102,7 +102,7 @@ function SessionInterceptorFactory($q: ng.IQService, $injector: ng.auto.IInjecto
       // - there is no active session
       // - for requests to refresh the authorization token
       // - for untrusted hosts
-      if (!$localStorage.authorization_token ||
+      if (!$localStorage['authorization_token'] ||
           config.url === `${process.env.IAM_API}/refresh` ||
           !appAuth.isTrustedURL(config.url)) {
         return config;
@@ -137,7 +137,7 @@ function SessionInterceptorFactory($q: ng.IQService, $injector: ng.auto.IInjecto
         // Wait for the refresh request promise, then add the new authorization token
         return refreshTokenPromise.then(() => {
           $log.debug(`SessionInterceptor: Adding authorization header for URL: ${config.url}`);
-          config.headers.Authorization = `Bearer ${$localStorage.authorization_token}`;
+          config.headers.Authorization = `Bearer ${$localStorage['authorization_token']}`;
           return config;
         }).catch(() => {
           $log.info(`SessionInterceptor: Auth token refresh failed, aborting request`);
@@ -149,7 +149,7 @@ function SessionInterceptorFactory($q: ng.IQService, $injector: ng.auto.IInjecto
 
       // Add the current authorization token
       $log.debug(`SessionInterceptor: Adding authorization header for URL: ${config.url}`);
-      config.headers.Authorization = `Bearer ${$localStorage.authorization_token}`;
+      config.headers.Authorization = `Bearer ${$localStorage['authorization_token']}`;
       return config;
     },
     responseError(response) {

--- a/src/session/session.module.ts
+++ b/src/session/session.module.ts
@@ -34,7 +34,6 @@ function SessionFactory($http: ng.IHttpService, $localStorage, $rootScope, $log:
       $log.info('Session: Refreshing authorization token');
       return $http.post(`${process.env.IAM_API}/refresh`, `refresh_token=${$localStorage.refresh_token.val}`, {
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        refreshTokenRequest: true,
       }).then(response => {
         $log.info('Session: Token refresh successful, saving new authorization token in local storage');
         $localStorage.authorization_token = response.data;
@@ -104,7 +103,7 @@ function SessionInterceptorFactory($q: ng.IQService, $injector: ng.auto.IInjecto
       // - for requests to refresh the authorization token
       // - for untrusted hosts
       if (!$localStorage.authorization_token ||
-          config.refreshTokenRequest ||
+          config.url === `${process.env.IAM_API}/refresh` ||
           !appAuth.isTrustedURL(config.url)) {
         return config;
       }

--- a/src/session/session.module.ts
+++ b/src/session/session.module.ts
@@ -3,7 +3,7 @@ import 'ngstorage';
 import querystring from 'query-string';
 
 
-function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast) {
+function SessionFactory($http: ng.IHttpService, $localStorage, $rootScope, $log: ng.ILogService, $state, $mdToast) {
   return {
     isAuthenticated() {
       return !this.expired();
@@ -88,7 +88,7 @@ function SessionFactory($http, $localStorage, $rootScope, $log, $state, $mdToast
   };
 }
 
-function SessionInterceptorFactory($q, $injector, appAuth) {
+function SessionInterceptorFactory($q: ng.IQService, $injector: ng.auto.IInjectorService, appAuth) {
 
   // Points to any ongoing request for refreshing the authorization token. Further requests should wait for this promise to resolve.
   let refreshTokenPromise;
@@ -169,7 +169,7 @@ export const SessionModule = angular
   ])
   .factory('Session', SessionFactory)
   .factory('sessionInterceptor', SessionInterceptorFactory)
-  .run(($rootScope, $state, $location, $log, $mdDialog, Session, Project, appAuth) => {
+  .run(($rootScope, $state, $location: ng.ILocationService, $log: ng.ILogService, $mdDialog, Session, Project, appAuth) => {
 
     if (!Session.isAuthenticated()) {
       $rootScope.isAuthenticated = false;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,8 @@ module.exports = function () {
                 'FIREBASE_DATABASE_URL',
                 'FIREBASE_PROJECT_ID',
                 'FIREBASE_STORAGE_BUCKET',
-                'FIREBASE_SENDER_ID'
+                'FIREBASE_SENDER_ID',
+                'IAM_API'
             ])
         ],
         module: {


### PR DESCRIPTION
This creates a new session module which overrides the built-in module in `metabolica-ui`. The new module supports the [IAM service API](https://github.com/dd-decaf/iam#api).

Notable changes:

* Login form now asks for email, not username
* IAM API endpoint is retrieved from `process.env.IAM_API`
* Automatically refreshes auth token if expired, using session token
* If session token is expired, forces user to re-authenticate
* `Session.getCurrentUser()` now always returns `null`, which means that the Account settings page from `metabolica-core` will be unusable